### PR TITLE
Standardize dependabot.yml and pin MiraGeoscience/CI-tools refs to @v3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,15 +12,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 4
-    ignore:
-      - dependency-name: "MiraGeoscience/CI-tools/.github/actions/*"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"
-      - dependency-name: "MiraGeoscience/CI-tools/.github/workflows/*"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,25 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      interval: "monthly"
     target-branch: "develop"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 4
+    ignore:
+      - dependency-name: "MiraGeoscience/CI-tools/.github/actions/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "MiraGeoscience/CI-tools/.github/workflows/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+    groups:
+      github-actions:
+        patterns:
+          - actions/*
+      mirageo-ci-tools:
+        patterns:
+          - MiraGeoscience/CI-tools/.github/actions/*
+          - MiraGeoscience/CI-tools/.github/workflows/*

--- a/.github/workflows/issue_to_jira.yml
+++ b/.github/workflows/issue_to_jira.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   call-workflow-create-jira-issue:
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-jira-issue_to_jira.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-jira-issue_to_jira.yml@v3
     secrets: inherit
     with:
       project-key: 'GEOPY'

--- a/.github/workflows/issue_to_jira.yml
+++ b/.github/workflows/issue_to_jira.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   call-workflow-create-jira-issue:
     uses: MiraGeoscience/CI-tools/.github/workflows/reusable-jira-issue_to_jira.yml@v3
-    secrets: inherit
+    permissions:
+      issues: write
+    secrets:
+      JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL_WRITE }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN_WRITE }}
     with:
-      project-key: 'GEOPY'
+      project_key: 'GEOPY'

--- a/.github/workflows/python_analysis.yml
+++ b/.github/workflows/python_analysis.yml
@@ -24,14 +24,14 @@ concurrency:
 jobs:
   call-workflow-static-analysis:
     name: Static analysis
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@v3
     with:
       package-manager: 'conda'
       app-name: 'surface_apps'
       python-version: '3.12'
   call-workflow-pytest:
     name: Pytest
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest.yml@v3
     with:
       package-manager: 'conda'
       python-versions: '["3.12", "3.13"]'

--- a/.github/workflows/python_deploy_dev.yml
+++ b/.github/workflows/python_deploy_dev.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   call-workflow-conda-publish:
     name: Publish development conda package on JFrog Artifactory
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-publish_rattler_package.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-publish_rattler_package.yml@v3
     with:
       package-name: 'surface-apps'
       python-version: '3.12'
@@ -25,7 +25,7 @@ jobs:
       JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
   call-workflow-pypi-publish:
     name: Publish development pypi package (JFrog Artifactory, TestPyPI)
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-publish_pypi_package.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-publish_pypi_package.yml@v3
     with:
       package-manager: 'poetry'
       package-name: 'surface-apps'

--- a/.github/workflows/python_deploy_prod.yml
+++ b/.github/workflows/python_deploy_prod.yml
@@ -27,7 +27,7 @@ jobs:
   call-workflow-conda-release:
     name: Publish production Conda package on JFrog Artifactory
     if: ${{ github.event_name == 'release' || github.event.inputs.publish-conda == 'true' }}
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-release_conda_assets.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-release_conda_assets.yml@v3
     with:
       virtual-repo-names: '["public-noremote-conda-prod"]'
       release-tag: ${{ github.event.release.tag_name || github.event.inputs.release-tag }}
@@ -37,7 +37,7 @@ jobs:
   call-workflow-pypi-release:
     name: Publish production PyPI package (JFrog Artifactory, PyPI)
     if: ${{ github.event_name == 'release' || github.event.inputs.publish-pypi == 'true' }}
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-release_pypi_assets.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-release_pypi_assets.yml@v3
     with:
       package-name: 'surface-apps'
       virtual-repo-names: '["public-pypi-prod", "pypi"]'


### PR DESCRIPTION
DEVOPS-1128: CI-tools config updates, applied wherever relevant to this repo:
- Standardize dependabot.yml's github-actions entry (weekly schedule, cooldown, mirageo-ci-tools group) to match the rest of the org.
- Pin any MiraGeoscience/CI-tools action/workflow ref that floated on @main/@v2/@v1.0.0 to @v3.

(Earlier revisions of this PR also added a dependabot ignore rule for CI-tools minor/patch updates - that's been dropped, we decided not to proceed with it.)

This PR was run by a PowerShell script with the help of Copilot.