### PR TITLE
GEOPY-2998: Update docs with release notes from GA 4.8 release

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,7 @@ Content
    usage
    iso_surfaces
    api_reference
+   release_notes
    THIRD_PARTY_SOFTWARE
 
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,0 +1,39 @@
+Release notes
+=============
+
+Release 0.1.0 (2026-07-01)
+--------------------------
+
+**(First release)**
+
+- GEOPY-523: Move iso-surface app to separate repo
+- GEOPY-1578: Prepare release for 0.1.0
+- GEOPY-1567: Clip surfaces by ndv of data values
+- GEOPY-1594: Crash on values shape
+- GEOPY-1569: Investigate conda_environment saved on geoapps run of curve_apps
+- GEOPY-1567: Clip surfaces by ndv of data values
+- GEOPY-1681: Streamline geoapps-utils
+- GEOPY-1681: Streamline geoapps-utils
+- DEVOPS-452: Update package with python-poetry-template
+- DEVOPS-440: Fixup README by using regular double quotes
+- GEOPY-1582: Formalize out_group as empty string or UIJsonGroup selector
+- DEVOPS-466: Update input variables in github shared workflows
+- GEOPY-1778: point development to geoh5py release/0.10.0
+- DEVOPS-515: release branches to prepare distrib for Analyst 4.5
+- DEVOPS-515: bump develop version to 0.2.0-alpha.1
+- DEVOPS-504: Automatically publish python package on Artifactory
+- DEVOPS-540: Test version consistency
+- GEOPY-1933: Update copyright date to 2025
+- DEVOPS-635: build conda package faster with rattler-build
+- GEOPY-1930: move 3rd-party license file under doc
+- GEOPY-1861: complete package readme and description
+- GEOPY-2036: wrong licence terms in surface apps
+- GEOPY-2049: relock on latest release branch revisions
+- GEOPY-2088: Application for surface normals to scatter point
+- DEVOPS-690: use Poetry 2 and have pyproject.toml checked by pre-commit
+- DEVOPS-545: auto-versioning-of-python-packages
+- GEOPY-2403: align versions of 3rd party dependencies across repositories
+- GEOPY-2704: wrong capitalisation in labels
+- DEVOPS-989: use reusable pr_jira_actions workflow
+- DEVOPS-1065: configure auto-versioning in local conda recipes
+- GEOPY-2911: Migrate surface-apps to python 3.12

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,34 +6,34 @@ Release 0.1.0 (2026-07-01)
 
 **(First release)**
 
-- GEOPY-523: Move iso-surface app to separate repo
-- GEOPY-1578: Prepare release for 0.1.0
-- GEOPY-1567: Clip surfaces by ndv of data values
-- GEOPY-1594: Crash on values shape
-- GEOPY-1569: Investigate conda_environment saved on geoapps run of curve_apps
-- GEOPY-1567: Clip surfaces by ndv of data values
-- GEOPY-1681: Streamline geoapps-utils
-- GEOPY-1681: Streamline geoapps-utils
-- DEVOPS-452: Update package with python-poetry-template
-- DEVOPS-440: Fixup README by using regular double quotes
-- GEOPY-1582: Formalize out_group as empty string or UIJsonGroup selector
-- DEVOPS-466: Update input variables in github shared workflows
-- GEOPY-1778: point development to geoh5py release/0.10.0
-- DEVOPS-515: release branches to prepare distrib for Analyst 4.5
-- DEVOPS-515: bump develop version to 0.2.0-alpha.1
-- DEVOPS-504: Automatically publish python package on Artifactory
-- DEVOPS-540: Test version consistency
-- GEOPY-1933: Update copyright date to 2025
-- DEVOPS-635: build conda package faster with rattler-build
-- GEOPY-1930: move 3rd-party license file under doc
-- GEOPY-1861: complete package readme and description
-- GEOPY-2036: wrong licence terms in surface apps
-- GEOPY-2049: relock on latest release branch revisions
-- GEOPY-2088: Application for surface normals to scatter point
-- DEVOPS-690: use Poetry 2 and have pyproject.toml checked by pre-commit
-- DEVOPS-545: auto-versioning-of-python-packages
-- GEOPY-2403: align versions of 3rd party dependencies across repositories
-- GEOPY-2704: wrong capitalisation in labels
-- DEVOPS-989: use reusable pr_jira_actions workflow
-- DEVOPS-1065: configure auto-versioning in local conda recipes
-- GEOPY-2911: Migrate surface-apps to python 3.12
+- Move iso-surface app to separate repo
+- Prepare release for 0.1.0
+- Clip surfaces by ndv of data values
+- Crash on values shape
+- Investigate conda_environment saved on geoapps run of curve_apps
+- Clip surfaces by ndv of data values
+- Streamline geoapps-utils
+- Streamline geoapps-utils
+- Update package with python-poetry-template
+- Fixup README by using regular double quotes
+- Formalize out_group as empty string or UIJsonGroup selector
+- Update input variables in github shared workflows
+- Point development to geoh5py release/0.10.0
+- Release branches to prepare distrib for Analyst 4.5
+- Bump develop version to 0.2.0-alpha.1
+- Automatically publish python package on Artifactory
+- Test version consistency
+- Update copyright date to 2025
+- Build conda package faster with rattler-build
+- Move 3rd-party license file under doc
+- Complete package readme and description
+- Wrong licence terms in surface apps
+- Relock on latest release branch revisions
+- Application for surface normals to scatter point
+- Use Poetry 2 and have pyproject.toml checked by pre-commit
+- Auto-versioning-of-python-packages
+- Align versions of 3rd party dependencies across repositories
+- Wrong capitalisation in labels
+- Use reusable pr_jira_actions workflow
+- Configure auto-versioning in local conda recipes
+- Migrate surface-apps to python 3.12

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,13 +11,12 @@ Release 0.1.0 (2026-07-01)
 - Clip surfaces by ndv of data values
 - Crash on values shape
 - Investigate conda_environment saved on geoapps run of curve_apps
-- Clip surfaces by ndv of data values
 - Streamline geoapps-utils
 - Streamline geoapps-utils
 - Update package with python-poetry-template
 - Fixup README by using regular double quotes
 - Formalize out_group as empty string or UIJsonGroup selector
-- Update input variables in github shared workflows
+- Update input variables in GitHub shared workflows
 - Point development to geoh5py release/0.10.0
 - Release branches to prepare distrib for Analyst 4.5
 - Bump develop version to 0.2.0-alpha.1


### PR DESCRIPTION
**GEOPY-2998 - Update docs with release notes from GA 4.8 release**
